### PR TITLE
fix: omada 5.12 client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	github.com/coredns/caddy v1.1.1
 	github.com/coredns/coredns v1.10.0
-	github.com/dougbw/go-omada v0.4.0
+	github.com/dougbw/go-omada v0.4.2
 	github.com/go-playground/validator/v10 v10.14.1
 	github.com/miekg/dns v1.1.50
 )

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dougbw/go-omada v0.4.0 h1:X7BMFq1vtmjqnu+kxqKJeXSXXDMVuJSrk5pBsTAEsWI=
 github.com/dougbw/go-omada v0.4.0/go.mod h1:Ia6D6xEl99ISvPfHY4uALEYmiqEwpd0uzbIQ82VjiQE=
+github.com/dougbw/go-omada v0.4.2 h1:D8IF/GBSaQm//LwDZVqvYx2uE6vBgHqrw9VRn66v6vM=
+github.com/dougbw/go-omada v0.4.2/go.mod h1:Ia6D6xEl99ISvPfHY4uALEYmiqEwpd0uzbIQ82VjiQE=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568 h1:BHsljHzVlRcyQhjrss6TZTdY2VfCqZPbv5k3iBFa2ZQ=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/gabriel-vasile/mimetype v1.4.2 h1:w5qFW6JKBz9Y393Y4q372O9A7cUSequkh1Q7OhCmWKU=


### PR DESCRIPTION
fix for the omada 5.12 update - bumps the go-omada library to the latest release: https://github.com/dougbw/go-omada/releases/tag/v0.4.2

resolves #16 