### PR TITLE
Move container images to github packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # docker buildx build --platform linux/amd64,linux/arm64 -t coredns-omada --load
 #
 # push command:
-# docker buildx build --platform linux/amd64,linux/arm64 -t dougbw1/coredns-omada:1.4.3 -t dougbw1/coredns-omada:latest --push .
+# docker buildx build --platform linux/amd64,linux/arm64 -t ghcr.io/dougbw/corends_omada:1.4.3 -t ghcr.io/dougbw/corends_omada:latest --push .
 #
 # How to setup multi platform builder:
 # docker buildx create --name multiplatform

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ coredns_omada is a [CoreDNS plugin](https://coredns.io/manual/plugins/) which re
 * [Building coredns omada](docs/build.md)
 * [Solution design](docs/solution-design.md)
 
-# Pre-build docker images
+# Pre-built docker images
 
-Docker container images are now being published to (GitHub)[https://github.com/dougbw/coredns_omada/pkgs/container/corends_omada] under the following name:
+Docker container images are now being published to the [GitHub Container Registry](https://github.com/dougbw/coredns_omada/pkgs/container/corends_omada) under the following name:
  `ghcr.io/dougbw/corends_omada`
 
 # Version chart

--- a/README.md
+++ b/README.md
@@ -7,10 +7,14 @@ coredns_omada is a [CoreDNS plugin](https://coredns.io/manual/plugins/) which re
 * [Building coredns omada](docs/build.md)
 * [Solution design](docs/solution-design.md)
 
+# Pre-build docker images
+
+Docker container images are now being published to (GitHub)[https://github.com/dougbw/coredns_omada/pkgs/container/corends_omada] under the following name:
+ `ghcr.io/dougbw/corends_omada`
 
 # Version chart
 
 | Omada Controller version  | coredns_omada version |
 | --------                  | -------               |
-| `5.12.x`                    | `v1.4.3`              |
-| `5.9.x`                     | `v1.4.2`              |
+| `5.12.x`                  | `v1.4.3`              |
+| `5.9.x`                   | `v1.4.2`              |

--- a/docs/docker-synology.md
+++ b/docs/docker-synology.md
@@ -15,7 +15,7 @@ docker run \
 --env OMADA_PASSWORD="<OMADA_PASSWORD>" \
 --env OMADA_DISABLE_HTTPS_VERIFICATION="false" \
 --env UPSTREAM_DNS="8.8.8.8" \
-dougbw1/coredns-omada:1.0.0 -conf /etc/coredns/Corefile
+ghcr.io/dougbw/corends_omada:latest -conf /etc/coredns/Corefile
 ```
 
 1. Install `Docker` from the Synology Package Center
@@ -28,7 +28,7 @@ dougbw1/coredns-omada:1.0.0 -conf /etc/coredns/Corefile
 
 3. Open the Docker management console (select it from installed packages in the Package Center) and go to the `Registry` tab.  
 	 - Search for the keyword `coredns-omada`
-	 - There should be one result that links to https://registry.hub.docker.com/r/dougbw1/coredns-omada/
+	 - There should be one result that links to https://registry.hub.docker.com/r/ghcr.io/dougbw/corends_omada/
 	 - Double click that Image to install and choose `Tag` = `Latest` when prompted. 
 	 - The coredns-omada image should now be available on the Image tab of the Docker management console.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -38,7 +38,7 @@ docker run \
 --env OMADA_PASSWORD="<OMADA_PASSWORD>" \
 --env OMADA_DISABLE_HTTPS_VERIFICATION="false" \
 --env UPSTREAM_DNS="8.8.8.8" \
-dougbw1/coredns-omada:latest -conf /etc/coredns/Corefile
+ghcr.io/dougbw/corends_omada:latest -conf /etc/coredns/Corefile
 ```
 Note: If you do not have a valid https certificate on your controller then set `OMADA_DISABLE_HTTPS_VERIFICATION` to true
 

--- a/k8s/deploy.yaml
+++ b/k8s/deploy.yaml
@@ -19,7 +19,7 @@ spec:
             name: coredns-omada
       containers:
         - name: coredns
-          image: dougbw1/coredns-omada:1.0.0 # {"$imagepolicy": "flux-system:coredns-omada"}
+          image: ghcr.io/dougbw/corends_omada:latest # {"$imagepolicy": "flux-system:coredns-omada"}
           args: ["-conf", "/etc/coredns/Corefile"]
           livenessProbe:
             httpGet:


### PR DESCRIPTION
Container images are now being published to github rather than docker hub