### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ RUN export DEBCONF_NONINTERACTIVE_SEEN=true \
 FROM --platform=$TARGETPLATFORM scratch
 COPY --from=certificates /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /coredns/coredns /coredns
-COPY Corefile /Corefile
+COPY Corefile /default-Corefile
 EXPOSE 53 53/udp
 ENTRYPOINT ["/coredns"]
+CMD ["-conf", "/default-Corefile"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,5 +40,6 @@ RUN export DEBCONF_NONINTERACTIVE_SEEN=true \
 FROM --platform=$TARGETPLATFORM scratch
 COPY --from=certificates /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /coredns/coredns /coredns
+COPY Corefile /Corefile
 EXPOSE 53 53/udp
 ENTRYPOINT ["/coredns"]


### PR DESCRIPTION
Add default Corefile to container

Useful if ppl dont want to use mounts for such a simple file and even then they just keep it default anyway.