### PR TITLE
Adding an example using the file plugin for additional hosts.

### DIFF
--- a/corefile-examples/additional-hosts/Corefile
+++ b/corefile-examples/additional-hosts/Corefile
@@ -1,0 +1,12 @@
+. {
+    health :8080
+    omada {
+        controller_url https://10.0.0.2
+        site Home
+        username coredns-omada
+        password coredns-omada
+        refresh_minutes 1
+    }
+    file omada.home omada.home
+    forward . 10.0.0.1
+}

--- a/corefile-examples/additional-hosts/omada.home
+++ b/corefile-examples/additional-hosts/omada.home
@@ -1,0 +1,13 @@
+$TTL    60
+$ORIGIN omada.home.
+
+@                       IN      SOA     ns1.omada.home. admin.omada.home. (
+                2024082900      ; serial
+                7200            ; refresh (2 hours)
+                3600            ; retry (1 hour)
+                1209600         ; expire (2 weeks)
+                3600            ; minimum (1 hour)
+                )
+
+name.omada.home.    IN  CNAME   existing.omada.home.
+


### PR DESCRIPTION
Here is an example Corefile and associated db file to illustrate how to use the file plugin in conjunction with omada to add additional hosts to the dns server. This is the recommended approach from #45 