### PR TITLE
allow wildcard dhcp reservation

### DIFF
--- a/dns.go
+++ b/dns.go
@@ -18,3 +18,17 @@ func makeDNSSafe(input string) string {
 
 	return input
 }
+
+func makeDNSSafeAllowWildcard(input string) string {
+	// Replace any whitespace with hyphens
+	input = strings.Replace(input, " ", "-", -1)
+
+	// Remove any characters that are not letters, numbers, hypens, wildcards or dots
+	re := regexp.MustCompile(`[^a-zA-Z0-9-\*\.]`)
+	input = re.ReplaceAllString(input, "")
+
+	// Convert the string to lower case
+	input = strings.ToLower(input)
+
+	return input
+}

--- a/update.go
+++ b/update.go
@@ -241,7 +241,7 @@ func (o *Omada) updateZones(ctx context.Context) error {
 				if reservation.ClientName == reservation.Mac && reservation.Description != "" {
 					dnsName = reservation.Description
 				}
-				reservationFqdn := fmt.Sprintf("%s.%s", makeDNSSafe(dnsName), dnsDomain)
+				reservationFqdn := fmt.Sprintf("%s.%s", makeDNSSafeAllowWildcard(dnsName), dnsDomain)
 				a := &dns.A{Hdr: dns.RR_Header{Name: reservationFqdn, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 60},
 					A: net.ParseIP(reservation.IP)}
 				records[dnsDomain].ARecords[reservationFqdn] = ARecord{


### PR DESCRIPTION
Allow wildcard records for DHCP reservations. See #45 

* In the Omada controller -> Services -> DHCP -> Create new DHCP reservation
* Select target network
* Enter a dummy MAC address: e.g `AA-AA-AA-AA-AA-AA`
* Enter the target IP address
* Enter the hostname e.g `*.kubernetes`
* The next refresh will setup a wildcard record e.g  if DNS domain is `omada.internal` then `*.kubernetes.omada.internal` will be created










