### PR TITLE
Add fallback wildcard generation logic [Draft]

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ coredns_omada is a [CoreDNS plugin](https://coredns.io/manual/plugins/) which re
 - Reverse DNS
 - Wildcard records
 - Multiple site support
+- Fallback configuration for unresolved queries (i.e. for reverse proxy setups)
 
 # Docs
 

--- a/config_test.go
+++ b/config_test.go
@@ -24,6 +24,33 @@ func TestConfig(t *testing.T) {
 			stale_record_duration 10m
 }`, false},
 
+		// valid config with fallback IP
+		{`omada {
+			controller_url https://10.0.0.1
+			username test
+			password test
+			site .*
+			fallback 192.168.1.100
+}`, false},
+
+		// valid config with fallback FQDN
+		{`omada {
+			controller_url https://10.0.0.1
+			username test
+			password test
+			site .*
+			fallback caddy.omada.home
+}`, false},
+
+		// valid config with fallback hostname
+		{`omada {
+			controller_url https://10.0.0.1
+			username test
+			password test
+			site .*
+			fallback caddy
+}`, false},
+
 		// missing required property: controller url
 		{`omada {
 			username test
@@ -122,6 +149,51 @@ func TestConfig(t *testing.T) {
 			password test
 			site .*
 			ignore_startup_errors zzz
+}`, true},
+
+		// valid config with empty fallback (no fallback configured)
+		{`omada {
+			controller_url https://10.0.0.1
+			username test
+			password test
+			site .*
+			fallback ""
+}`, false},
+
+		// invalid value: fallback too long
+		{`omada {
+			controller_url https://10.0.0.1
+			username test
+			password test
+			site .*
+			fallback ` + "verylongfallbackdomainnamethatexceedsthe253characterlimitfordnsdomainnamesandshouldberejectedduetobeingtoolargeforvaliddomainnamespecificationsaccordingtointernetstandardswhichspecifythemaximumlengthfordomainnamestonotexceed253charactersintotallengthhereismoretexttoensurewereachthatlimitandcauseavalidationfailure" + `
+}`, true},
+
+		// invalid value: fallback with invalid characters
+		{`omada {
+			controller_url https://10.0.0.1
+			username test
+			password test
+			site .*
+			fallback "invalid@domain"
+}`, true},
+
+		// invalid value: fallback with hyphen in label
+		{`omada {
+			controller_url https://10.0.0.1
+			username test
+			password test
+			site .*
+			fallback "api.-server.example.com"
+}`, true},
+
+		// invalid value: fallback with IPv6 address (not supported)
+		{`omada {
+			controller_url https://10.0.0.1
+			username test
+			password test
+			site .*
+			fallback "2001:db8::1"
 }`, true},
 	}
 

--- a/corefile-examples/environment-variables/Corefile
+++ b/corefile-examples/environment-variables/Corefile
@@ -6,6 +6,7 @@
         username {$OMADA_USERNAME}
         password {$OMADA_PASSWORD}
         refresh_minutes 1
+        fallback {$FALLBACK_HOST}
     }
     forward . {$UPSTREAM_DNS}
 }

--- a/corefile-examples/environment-variables/readme.md
+++ b/corefile-examples/environment-variables/readme.md
@@ -4,8 +4,9 @@ This example sources the values from environment variables using the convention 
 
 * `controller_url` -> from the `OMADA_URL` environment variable
 * `site` -> from the `OMADA_SITE` environment variable
-* `username` -> from the `OMADA_URL` environment variable
-* `password` -> from the `OMADA_URL` environment variable
+* `username` -> from the `OMADA_USERNAME` environment variable
+* `password` -> from the `OMADA_PASSWORD` environment variable
+* `fallback` -> from the `FALLBACK_HOST` environment variable (optional - empty string disables fallback)
 * `forward` server -> from the `UPSTREAM_DNS` environment variable
 
 

--- a/corefile-examples/standard/Corefile
+++ b/corefile-examples/standard/Corefile
@@ -6,6 +6,7 @@
         username coredns-omada
         password coredns-omada
         refresh_minutes 1
+        fallback 10.0.0.3
     }
     forward . 10.0.0.1
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,6 +13,7 @@ Example corefiles are located [here](../corefile-examples)
 | site                      | ✅        | string   | name of the site from the Omada controller (note this is a regex pattern)                                                                                    |
 | username                  | ✅        | string   | Omada controller username                                                                                                                                    |
 | password                  | ✅        | string   | Omada controller password                                                                                                                                    |
+| fallback                  | ❌        | string   | IPv4 address, FQDN, or hostname to redirect unresolved queries within managed zones. Creates wildcard DNS records automatically. Empty string disables fallback |
 | refresh_minutes           | ❌        | int      | How often to refresh the zones (default 1 minute)                                                                                                            |
 | refresh_login_hours       | ❌        | int      | How often to refresh the login token (default 24 hours)                                                                                                      |
 | resolve_clients           | ❌        | bool     | Whether to resolve client addresses (default true)                                                                                                                        |
@@ -51,3 +52,15 @@ It is possible to create a dummy DHCP reservation in the Omada controller to cre
     - Example: ![image](dhcp-reservation.png)
 
 Note that wildcard records are supported by setting the client name to `*.<subdomain>` e.g `*.apps`.
+
+## Fallback Configuration
+
+The `fallback` option provides automatic creation of a wildcard record. This is useful for automatically drecting to a reverse proxy across all zones. The created wildcard entry can also have a duplicate IP address to existing hostname records (unlike custom DNS records created by DHCP reservation).
+
+The fallback can be configured as:
+
+- **IP address**: Direct IP redirection (e.g., `192.168.1.100`)
+- **FQDN**: Fully qualified domain name (e.g., `proxy.omada.home`)
+- **Hostname**: Simple hostname that exists in your zones (e.g., `proxy`)
+
+The FQDN and Hostname configurations must be able to resolve within the configured zones during updates as the wildcard entry will create an IP record.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -52,6 +52,9 @@ Note: If you do not have a valid https certificate on your controller then set t
 * `OMADA_PASSWORD`
 * `UPSTREAM_DNS`
 
+Optional environment variables:
+* `FALLBACK_HOST` - IP address, FQDN, or hostname for fallback DNS resolution
+
 Note: If you do not have a valid https certificate on your controller then set the `OMADA_DISABLE_HTTPS_VERIFICATION` environment variable to true
 
 Example docker run command:
@@ -66,6 +69,7 @@ docker run \
 --env OMADA_IGNORE_STARTUP_ERRORS="false" \
 --env OMADA_DISABLE_HTTPS_VERIFICATION="false" \
 --env UPSTREAM_DNS="8.8.8.8" \
+--env FALLBACK_HOST="<FALLBACK_HOST>" \
 ghcr.io/dougbw/coredns_omada:latest
 ```
 

--- a/omada_test.go
+++ b/omada_test.go
@@ -59,7 +59,7 @@ func testZonesWithFallback() map[string]*file.Zone {
 			Name:   wildcardName,
 			Rrtype: dns.TypeA,
 			Class:  dns.ClassINET,
-			Ttl:    300,
+			Ttl:    60,
 		},
 		A: net.ParseIP(fallbackIP),
 	}
@@ -157,13 +157,13 @@ func TestOmadaWithFallback(t *testing.T) {
 		{
 			qname:      "nonexistent.omada.test.",
 			qtype:      dns.TypeA,
-			wantAnswer: []string{"nonexistent.omada.test.	300	IN	A	10.0.0.100"},
+			wantAnswer: []string{"nonexistent.omada.test.	60	IN	A	10.0.0.100"},
 		},
 		// Another non-existent record should also fallback
 		{
 			qname:      "app.omada.test.",
 			qtype:      dns.TypeA,
-			wantAnswer: []string{"app.omada.test.	300	IN	A	10.0.0.100"},
+			wantAnswer: []string{"app.omada.test.	60	IN	A	10.0.0.100"},
 		},
 		// SOA record should still work
 		{

--- a/update.go
+++ b/update.go
@@ -365,7 +365,7 @@ func (o *Omada) addFallbackRecord(zones map[string]*file.Zone, dnsDomain string,
 			Name:   wildcardName,
 			Rrtype: dns.TypeA,
 			Class:  dns.ClassINET,
-			Ttl:    300,
+			Ttl:    60,
 		},
 		A: fallbackIP,
 	}

--- a/update_test.go
+++ b/update_test.go
@@ -132,5 +132,260 @@ func TestUpdate(t *testing.T) {
 		},
 	}
 	executeTestCases(t, testOmada, tests)
+}
+
+func TestUpdateWithFallback(t *testing.T) {
+	testServer := setupTestServer()
+	defer testServer.Close()
+
+	url := testServer.URL
+	u := "test"
+	p := "test"
+	testOmada, err := NewOmada(context.TODO(), url, u, p)
+	if err != nil {
+		t.Fatalf("test failure on 'TestUpdateWithFallback/NewOmada': %v", err)
+	}
+	testOmada.Next = testHandler()
+
+	err = testOmada.controllerInit(context.TODO())
+	if err != nil {
+		t.Fatalf("test failure on 'TestUpdateWithFallback/controllerInit': %v", err)
+	}
+
+	// Configure with fallback IP
+	testOmada.config.refresh_minutes = 1
+	testOmada.config.refresh_login_hours = 24
+	testOmada.config.resolve_clients = true
+	testOmada.config.resolve_devices = true
+	testOmada.config.resolve_dhcp_reservations = true
+	testOmada.config.stale_record_duration, _ = time.ParseDuration("5m")
+	testOmada.config.fallback = "10.0.0.200" // Fallback IP
+
+	var sites []string
+	for s := range testOmada.controller.Sites {
+		sites = append(sites, s)
+	}
+	testOmada.sites = sites
+	assert.Len(t, testOmada.sites, 1)
+
+	err = testOmada.updateZones()
+	if err != nil {
+		t.Fatalf("test failure on 'TestUpdateWithFallback/updateZones': %v", err)
+	}
+
+	assert.Len(t, testOmada.zoneNames, 3)
+	assert.Len(t, testOmada.zones, 3)
+	// Should have one more record due to wildcard fallback
+	assert.Equal(t, 14, testOmada.zones["omada.home."].Count)
+
+	tests := []testCases{
+		{ // existing record should work normally
+			qname:      "client-001.omada.home.",
+			qtype:      dns.TypeA,
+			wantAnswer: []string{"client-001.omada.home.	60	IN	A	10.0.0.101"},
+		},
+		{ // non-existent record should fallback to wildcard
+			qname:      "nonexistent.omada.home.",
+			qtype:      dns.TypeA,
+			wantAnswer: []string{"nonexistent.omada.home.	300	IN	A	10.0.0.200"},
+		},
+		{ // another non-existent record should also fallback
+			qname:      "app.omada.home.",
+			qtype:      dns.TypeA,
+			wantAnswer: []string{"app.omada.home.	300	IN	A	10.0.0.200"},
+		},
+		{ // existing wildcard reservation should take precedence
+			qname:      "test.kubernetes.omada.home",
+			qtype:      dns.TypeA,
+			wantAnswer: []string{"test.kubernetes.omada.home.	60	IN	A	10.0.0.150"},
+		},
+	}
+	executeTestCases(t, testOmada, tests)
+}
+
+func TestUpdateWithLocalHostnameFallback(t *testing.T) {
+	testServer := setupTestServer()
+	defer testServer.Close()
+
+	url := testServer.URL
+	u := "test"
+	p := "test"
+	testOmada, err := NewOmada(context.TODO(), url, u, p)
+	if err != nil {
+		t.Fatalf("test failure on 'TestUpdateWithLocalHostnameFallback/NewOmada': %v", err)
+	}
+	testOmada.Next = testHandler()
+
+	err = testOmada.controllerInit(context.TODO())
+	if err != nil {
+		t.Fatalf("test failure on 'TestUpdateWithLocalHostnameFallback/controllerInit': %v", err)
+	}
+
+	// Configure with local hostname fallback that should resolve to existing record
+	testOmada.config.refresh_minutes = 1
+	testOmada.config.refresh_login_hours = 24
+	testOmada.config.resolve_clients = true
+	testOmada.config.resolve_devices = true
+	testOmada.config.resolve_dhcp_reservations = true
+	testOmada.config.stale_record_duration, _ = time.ParseDuration("5m")
+	testOmada.config.fallback = "client-001" // Should resolve to existing client record
+
+	var sites []string
+	for s := range testOmada.controller.Sites {
+		sites = append(sites, s)
+	}
+	testOmada.sites = sites
+
+	err = testOmada.updateZones()
+	if err != nil {
+		t.Fatalf("test failure on 'TestUpdateWithLocalHostnameFallback/updateZones': %v", err)
+	}
+
+	// Should have one more record due to wildcard fallback
+	assert.Equal(t, 14, testOmada.zones["omada.home."].Count)
+
+	tests := []testCases{
+		{ // existing record should work normally
+			qname:      "client-001.omada.home.",
+			qtype:      dns.TypeA,
+			wantAnswer: []string{"client-001.omada.home.	60	IN	A	10.0.0.101"},
+		},
+		{ // existing record should work normally
+			qname:      "win10-vm.omada.home.",
+			qtype:      dns.TypeA,
+			wantAnswer: []string{"win10-vm.omada.home.	60	IN	A	10.0.0.102"},
+		},
+		{ // non-existent record should fallback to client-001 IP
+			qname:      "app.omada.home.",
+			qtype:      dns.TypeA,
+			wantAnswer: []string{"app.omada.home.	300	IN	A	10.0.0.101"},
+		},
+		{ // another non-existent record should also fallback
+			qname:      "service.omada.home.",
+			qtype:      dns.TypeA,
+			wantAnswer: []string{"service.omada.home.	300	IN	A	10.0.0.101"},
+		},
+		{ // existing wildcard reservation should take precedence
+			qname:      "test.kubernetes.omada.home",
+			qtype:      dns.TypeA,
+			wantAnswer: []string{"test.kubernetes.omada.home.	60	IN	A	10.0.0.150"},
+		},
+	}
+	executeTestCases(t, testOmada, tests)
+}
+
+func TestUpdateWithFqdnFallback(t *testing.T) {
+	testServer := setupTestServer()
+	defer testServer.Close()
+
+	url := testServer.URL
+	u := "test"
+	p := "test"
+	testOmada, err := NewOmada(context.TODO(), url, u, p)
+	if err != nil {
+		t.Fatalf("test failure on 'TestUpdateWithFqdnFallback/NewOmada': %v", err)
+	}
+	testOmada.Next = testHandler()
+
+	err = testOmada.controllerInit(context.TODO())
+	if err != nil {
+		t.Fatalf("test failure on 'TestUpdateWithFqdnFallback/controllerInit': %v", err)
+	}
+
+	// Configure with FQDN fallback that should resolve to existing record
+	testOmada.config.refresh_minutes = 1
+	testOmada.config.refresh_login_hours = 24
+	testOmada.config.resolve_clients = true
+	testOmada.config.resolve_devices = true
+	testOmada.config.resolve_dhcp_reservations = true
+	testOmada.config.stale_record_duration, _ = time.ParseDuration("5m")
+	testOmada.config.fallback = "client-001.omada.home." // Should resolve to existing client FQDN
+
+	var sites []string
+	for s := range testOmada.controller.Sites {
+		sites = append(sites, s)
+	}
+	testOmada.sites = sites
+
+	err = testOmada.updateZones()
+	if err != nil {
+		t.Fatalf("test failure on 'TestUpdateWithFqdnFallback/updateZones': %v", err)
+	}
+
+	// Should have one more record due to wildcard fallback
+	assert.Equal(t, 14, testOmada.zones["omada.home."].Count)
+
+	tests := []testCases{
+		{ // existing record should work normally
+			qname:      "client-001.omada.home.",
+			qtype:      dns.TypeA,
+			wantAnswer: []string{"client-001.omada.home.	60	IN	A	10.0.0.101"},
+		},
+		{ // non-existent record should fallback to client-001 FQDN IP
+			qname:      "app.omada.home.",
+			qtype:      dns.TypeA,
+			wantAnswer: []string{"app.omada.home.	300	IN	A	10.0.0.101"},
+		},
+	}
+
+	// Execute base test cases
+	executeTestCases(t, testOmada, tests)
+}
+
+func TestUpdateWithHostnameNotFoundFallback(t *testing.T) {
+	testServer := setupTestServer()
+	defer testServer.Close()
+
+	url := testServer.URL
+	u := "test"
+	p := "test"
+	testOmada, err := NewOmada(context.TODO(), url, u, p)
+	if err != nil {
+		t.Fatalf("test failure on 'TestUpdateWithHostnameFallback/NewOmada': %v", err)
+	}
+	testOmada.Next = testHandler()
+
+	err = testOmada.controllerInit(context.TODO())
+	if err != nil {
+		t.Fatalf("test failure on 'TestUpdateWithHostnameFallback/controllerInit': %v", err)
+	}
+
+	// Configure with hostname fallback that won't be found (testing warning case)
+	testOmada.config.refresh_minutes = 1
+	testOmada.config.refresh_login_hours = 24
+	testOmada.config.resolve_clients = true
+	testOmada.config.resolve_devices = true
+	testOmada.config.resolve_dhcp_reservations = true
+	testOmada.config.stale_record_duration, _ = time.ParseDuration("5m")
+	testOmada.config.fallback = "nonexistent-host" // Should not be found
+
+	var sites []string
+	for s := range testOmada.controller.Sites {
+		sites = append(sites, s)
+	}
+	testOmada.sites = sites
+
+	err = testOmada.updateZones()
+	if err != nil {
+		t.Fatalf("test failure on 'TestUpdateWithHostnameFallback/updateZones': %v", err)
+	}
+
+	// Should NOT have extra record since fallback wasn't found
+	assert.Equal(t, 13, testOmada.zones["omada.home."].Count)
+
+	tests := []testCases{
+		{ // existing record should work normally
+			qname:      "client-001.omada.home.",
+			qtype:      dns.TypeA,
+			wantAnswer: []string{"client-001.omada.home.	60	IN	A	10.0.0.101"},
+		},
+		{ // non-existent record should fail (no fallback added)
+			qname:        "app.omada.home.",
+			qtype:        dns.TypeA,
+			wantRetCode:  dns.RcodeServerFailure,
+			wantMsgRCode: dns.RcodeServerFailure,
+		},
+	}
+	executeTestCases(t, testOmada, tests)
 
 }

--- a/update_test.go
+++ b/update_test.go
@@ -187,12 +187,12 @@ func TestUpdateWithFallback(t *testing.T) {
 		{ // non-existent record should fallback to wildcard
 			qname:      "nonexistent.omada.home.",
 			qtype:      dns.TypeA,
-			wantAnswer: []string{"nonexistent.omada.home.	300	IN	A	10.0.0.200"},
+			wantAnswer: []string{"nonexistent.omada.home.	60	IN	A	10.0.0.200"},
 		},
 		{ // another non-existent record should also fallback
 			qname:      "app.omada.home.",
 			qtype:      dns.TypeA,
-			wantAnswer: []string{"app.omada.home.	300	IN	A	10.0.0.200"},
+			wantAnswer: []string{"app.omada.home.	60	IN	A	10.0.0.200"},
 		},
 		{ // existing wildcard reservation should take precedence
 			qname:      "test.kubernetes.omada.home",
@@ -258,12 +258,12 @@ func TestUpdateWithLocalHostnameFallback(t *testing.T) {
 		{ // non-existent record should fallback to client-001 IP
 			qname:      "app.omada.home.",
 			qtype:      dns.TypeA,
-			wantAnswer: []string{"app.omada.home.	300	IN	A	10.0.0.101"},
+			wantAnswer: []string{"app.omada.home.	60	IN	A	10.0.0.101"},
 		},
 		{ // another non-existent record should also fallback
 			qname:      "service.omada.home.",
 			qtype:      dns.TypeA,
-			wantAnswer: []string{"service.omada.home.	300	IN	A	10.0.0.101"},
+			wantAnswer: []string{"service.omada.home.	60	IN	A	10.0.0.101"},
 		},
 		{ // existing wildcard reservation should take precedence
 			qname:      "test.kubernetes.omada.home",
@@ -324,7 +324,7 @@ func TestUpdateWithFqdnFallback(t *testing.T) {
 		{ // non-existent record should fallback to client-001 FQDN IP
 			qname:      "app.omada.home.",
 			qtype:      dns.TypeA,
-			wantAnswer: []string{"app.omada.home.	300	IN	A	10.0.0.101"},
+			wantAnswer: []string{"app.omada.home.	60	IN	A	10.0.0.101"},
 		},
 	}
 


### PR DESCRIPTION
Existing wildcards don't support my use-case of a reverse proxy without causing IP conflict issues when creating the DHCP reservation. I'm sure a more adept user of coredns could have updated their corefile, but multiple plugins, forwards, and everything I (and google) could think to try failed to add a wildcard. Rather than write a custom plugin just for this and try to compile it with coredns_omada I figured it would be reasonable to generate an extra entry in my zones based on the plugin configuration.

This logic takes the approach of adding a config with three forms (my use-case is the full domain name, but the other two seemed clear) to generate a wildcard entry during update. I have tried to cover the right amount of detail for its purpose and configuration in the doc changes so hopefully that explains what this PR does.

Some decisions I made which may be relevant
- I made no attempt to support localization characters in domains, but wanted to do some string sanitization so in the end they are not supported, if you have a better suggestion let me know.
- I explicitly did not support IPv6 since coredns_omada doesn't have AAAA records today.
- I did not add the option for a CNAME record (a hostname must resolve from the omada hosts) as this would change the type of records the code is dealing with. I could see this being useful, but I wasn't comfortable making such extensive edits.

Lastly, I did not tackle adding additional test data for true cross-zone scenarios. I will do some live-fire tests in the next few days, but if you can help provide some tips on expanding the json data the following would be reasonable to check
- Single-label hostname only creates (and answers) wildcards in domains where it matches (positive and negative case)
- Behavior of full hostname in a configured and non-configured zone

Please also let me know if you have concerns with the testing approach - I tried to follow existing examples, but in many ways the enabling of fallback option required an extra instance or two to due to how its state impacts the different objects.